### PR TITLE
Removing symfony/console dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     "require": {
         "php": ">=7.0",
         "league/container": "^2.2",
-        "vlucas/phpdotenv": "^2.4",
-        "symfony/console": ">=2.8 <5.0"
+        "vlucas/phpdotenv": "^2.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",


### PR DESCRIPTION
Removing symfony/console dependency from root package to use the one declared in the friendsofphp/php-cs-fixer instead,